### PR TITLE
feat(annotator): 实现动态规则字段配置系统

### DIFF
--- a/module/server/annotator_rule_schema.py
+++ b/module/server/annotator_rule_schema.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+from collections import OrderedDict
+from copy import deepcopy
+from typing import Any
+
+RULE_TYPE_SCHEMAS: OrderedDict[str, dict[str, Any]] = OrderedDict(
+    {
+        "image": {
+            "type": "image",
+            "label": "RuleImage",
+            "capabilities": {
+                "supports_test": True,
+                "supports_crop": True,
+                "supports_image_preview": True,
+                "shared_roi_back": False,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+                {
+                    "key": "imageName",
+                    "label": "imageName",
+                    "control": "text",
+                    "default": "",
+                    "auto_from_item_name": True,
+                },
+                {
+                    "key": "method",
+                    "label": "method",
+                    "control": "select",
+                    "default": "Template matching",
+                    "options": ["Template matching", "Sift Flann"],
+                },
+                {
+                    "key": "threshold",
+                    "label": "threshold",
+                    "control": "number",
+                    "default": 0.8,
+                    "step": 0.01,
+                    "min": 0,
+                    "max": 1,
+                    "integer": False,
+                },
+                {"key": "description", "label": "description", "control": "textarea", "default": "", "full": True},
+            ],
+        },
+        "ocr": {
+            "type": "ocr",
+            "label": "RuleOcr",
+            "capabilities": {
+                "supports_test": True,
+                "supports_crop": False,
+                "supports_image_preview": False,
+                "shared_roi_back": False,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+                {
+                    "key": "mode",
+                    "label": "mode",
+                    "control": "select",
+                    "default": "Single",
+                    "options": ["Single", "Full", "Digit", "DigitCounter", "Duration", "Quantity"],
+                },
+                {"key": "method", "label": "method", "control": "text", "default": "Default"},
+                {"key": "keyword", "label": "keyword", "control": "text", "default": ""},
+                {"key": "description", "label": "description", "control": "textarea", "default": "", "full": True},
+            ],
+        },
+        "click": {
+            "type": "click",
+            "label": "RuleClick",
+            "capabilities": {
+                "supports_test": False,
+                "supports_crop": False,
+                "supports_image_preview": False,
+                "shared_roi_back": False,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+                {"key": "description", "label": "description", "control": "textarea", "default": "", "full": True},
+            ],
+        },
+        "swipe": {
+            "type": "swipe",
+            "label": "RuleSwipe",
+            "capabilities": {
+                "supports_test": False,
+                "supports_crop": False,
+                "supports_image_preview": False,
+                "shared_roi_back": False,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+                {
+                    "key": "mode",
+                    "label": "mode",
+                    "control": "select",
+                    "default": "default",
+                    "options": ["default", "vector"],
+                },
+                {"key": "description", "label": "description", "control": "textarea", "default": "", "full": True},
+            ],
+        },
+        "long_click": {
+            "type": "long_click",
+            "label": "RuleLongClick",
+            "capabilities": {
+                "supports_test": False,
+                "supports_crop": False,
+                "supports_image_preview": False,
+                "shared_roi_back": False,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+                {
+                    "key": "duration",
+                    "label": "duration(ms)",
+                    "control": "number",
+                    "default": 1000,
+                    "min": 1,
+                    "step": 1,
+                    "integer": True,
+                },
+                {"key": "description", "label": "description", "control": "textarea", "default": "", "full": True},
+            ],
+        },
+        "list": {
+            "type": "list",
+            "label": "RuleList",
+            "capabilities": {
+                "supports_test": True,
+                "supports_crop": True,
+                "supports_image_preview": True,
+                "shared_roi_back": True,
+            },
+            "fields": [
+                {"key": "itemName", "label": "itemName", "control": "text", "default": "new"},
+            ],
+            "meta_fields": [
+                {"key": "name", "label": "list.name", "control": "text", "default": "list_name"},
+                {
+                    "key": "direction",
+                    "label": "list.direction",
+                    "control": "select",
+                    "default": "vertical",
+                    "options": ["vertical", "horizontal"],
+                },
+                {
+                    "key": "type",
+                    "label": "list.type",
+                    "control": "select",
+                    "default": "image",
+                    "options": ["image", "ocr"],
+                },
+                {"key": "description", "label": "list.description", "control": "text", "default": ""},
+            ],
+        },
+    }
+)
+
+
+ROI_DEFAULT = "0,0,100,100"
+
+
+def get_rule_types() -> list[str]:
+    return list(RULE_TYPE_SCHEMAS.keys())
+
+
+def get_rule_schema(rule_type: str) -> dict[str, Any]:
+    schema = RULE_TYPE_SCHEMAS.get(str(rule_type or "").strip())
+    if not schema:
+        schema = RULE_TYPE_SCHEMAS["image"]
+    return deepcopy(schema)
+
+
+def get_rule_schemas() -> list[dict[str, Any]]:
+    return [get_rule_schema(rule_type) for rule_type in get_rule_types()]
+
+
+def get_schema_payload() -> dict[str, Any]:
+    return {
+        "rule_types": get_rule_types(),
+        "schemas": {rule_type: get_rule_schema(rule_type) for rule_type in get_rule_types()},
+    }
+
+
+def _field_defaults(fields: list[dict[str, Any]]) -> dict[str, Any]:
+    return {field["key"]: deepcopy(field.get("default")) for field in fields}
+
+
+def default_rule(rule_type: str) -> dict[str, Any]:
+    schema = get_rule_schema(rule_type)
+    rule = _field_defaults(schema.get("fields", []))
+    rule["roiFront"] = ROI_DEFAULT
+    if rule_type != "list":
+        rule["roiBack"] = ROI_DEFAULT
+    return rule
+
+
+def default_list_meta() -> dict[str, Any]:
+    schema = get_rule_schema("list")
+    meta = _field_defaults(schema.get("meta_fields", []))
+    meta["roiBack"] = ROI_DEFAULT
+    return meta
+
+
+def merge_rule_with_defaults(rule_type: str, rule: dict[str, Any] | None) -> dict[str, Any]:
+    merged = default_rule(rule_type)
+    if isinstance(rule, dict):
+        merged.update(rule)
+    if rule_type == "list":
+        merged.pop("description", None)
+    return merged
+
+
+def merge_list_meta_with_defaults(meta: dict[str, Any] | None) -> dict[str, Any]:
+    merged = default_list_meta()
+    if isinstance(meta, dict):
+        merged.update(meta)
+    return merged
+
+
+def field_default(rule_type: str, key: str, fallback: Any = None) -> Any:
+    schema = get_rule_schema(rule_type)
+    fields = list(schema.get("fields", [])) + list(schema.get("meta_fields", []))
+    for field in fields:
+        if field.get("key") == key:
+            return deepcopy(field.get("default"))
+    return fallback
+
+
+def field_options(rule_type: str, key: str) -> list[str]:
+    schema = get_rule_schema(rule_type)
+    fields = list(schema.get("fields", [])) + list(schema.get("meta_fields", []))
+    for field in fields:
+        if field.get("key") == key:
+            return list(field.get("options", []))
+    return []

--- a/module/server/tool.py
+++ b/module/server/tool.py
@@ -23,6 +23,15 @@ from module.config.config import Config
 from module.device.device import Device
 from module.logger import logger
 from module.server.config_manager import ConfigManager
+from module.server.annotator_rule_schema import (
+    default_list_meta,
+    field_default,
+    field_options,
+    get_rule_types,
+    get_schema_payload,
+    merge_list_meta_with_defaults,
+    merge_rule_with_defaults,
+)
 
 logger.set_file_logger('tool', do_cleanup=True)
 
@@ -31,10 +40,11 @@ TASKS_ROOT = (PROJECT_ROOT / "tasks").resolve()
 ANNOTATOR_ROOT = (PROJECT_ROOT / "log" / "annotator").resolve()
 
 ALLOWED_IMAGE_EXT = {".png", ".jpg", ".jpeg", ".bmp", ".webp"}
-ALLOWED_OCR_MODE = {"Single", "Full", "Digit", "DigitCounter", "Duration"}
-ALLOWED_LIST_DIRECTION = {"vertical", "horizontal"}
-ALLOWED_LIST_MODE = {"image", "ocr"}
-ALLOWED_SWIPE_MODE = {"default", "vector"}
+ALLOWED_RULE_TYPE = set(get_rule_types())
+ALLOWED_OCR_MODE = set(field_options("ocr", "mode"))
+ALLOWED_LIST_DIRECTION = set(field_options("list", "direction"))
+ALLOWED_LIST_MODE = set(field_options("list", "type"))
+ALLOWED_SWIPE_MODE = set(field_options("swipe", "mode"))
 
 SESSION_IDLE_TIMEOUT_SECONDS = 10 * 60
 SESSION_SWEEP_INTERVAL_SECONDS = 30
@@ -608,6 +618,10 @@ class AnnotatorManager:
     def list_configs(self) -> list[str]:
         return ConfigManager.all_script_files()
 
+    @staticmethod
+    def rule_schema() -> dict[str, Any]:
+        return get_schema_payload()
+
     def start_emulator(self, session_id: str, config_name: str, frame_rate: int) -> dict[str, Any]:
         session = self._get_session(session_id)
         if config_name not in self.list_configs():
@@ -690,7 +704,7 @@ class AnnotatorManager:
                     "imageName": image_name,
                     "roiFront": self._parse_roi(str(rule.get("roiFront", ""))),
                     "roiBack": self._parse_roi(str(rule.get("roiBack", ""))),
-                    "method": str(rule.get("method", "Template matching")).strip() or "Template matching",
+                    "method": str(rule.get("method", field_default("image", "method", "Template matching"))).strip() or field_default("image", "method", "Template matching"),
                     "threshold": threshold,
                     "description": str(rule.get("description", "")).strip(),
                 }
@@ -703,7 +717,7 @@ class AnnotatorManager:
             item_name = str(rule.get("itemName", "")).strip()
             if not item_name:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条规则缺少 itemName", 400)
-            mode = str(rule.get("mode", "Single")).strip() or "Single"
+            mode = str(rule.get("mode", field_default("ocr", "mode", "Single"))).strip() or field_default("ocr", "mode", "Single")
             if mode not in ALLOWED_OCR_MODE:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条规则 mode 不支持: {mode}", 400)
             normalized.append(
@@ -712,7 +726,7 @@ class AnnotatorManager:
                     "roiFront": self._parse_roi(str(rule.get("roiFront", ""))),
                     "roiBack": self._parse_roi(str(rule.get("roiBack", ""))),
                     "mode": mode,
-                    "method": str(rule.get("method", "Default")).strip() or "Default",
+                    "method": str(rule.get("method", field_default("ocr", "method", "Default"))).strip() or field_default("ocr", "method", "Default"),
                     "keyword": str(rule.get("keyword", "")).strip(),
                     "description": str(rule.get("description", "")).strip(),
                 }
@@ -741,7 +755,7 @@ class AnnotatorManager:
             item_name = str(rule.get("itemName", "")).strip()
             if not item_name:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条滑动规则缺少 itemName", 400)
-            mode = str(rule.get("mode", "default")).strip() or "default"
+            mode = str(rule.get("mode", field_default("swipe", "mode", "default"))).strip() or field_default("swipe", "mode", "default")
             if mode not in ALLOWED_SWIPE_MODE:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条滑动规则 mode 不支持: {mode}", 400)
             normalized.append(
@@ -762,7 +776,7 @@ class AnnotatorManager:
             if not item_name:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条长按规则缺少 itemName", 400)
             try:
-                duration = int(rule.get("duration", 1000))
+                duration = int(rule.get("duration", field_default("long_click", "duration", 1000)))
             except (TypeError, ValueError) as e:
                 raise AnnotatorError("invalid_rule", f"第 {index + 1} 条长按规则 duration 非法", 400) from e
             if duration <= 0:
@@ -786,11 +800,11 @@ class AnnotatorManager:
         if not list_name:
             raise AnnotatorError("invalid_rule", "list_meta.name 不能为空", 400)
 
-        direction = str(list_meta.get("direction", "vertical")).strip() or "vertical"
+        direction = str(list_meta.get("direction", field_default("list", "direction", "vertical"))).strip() or field_default("list", "direction", "vertical")
         if direction not in ALLOWED_LIST_DIRECTION:
             raise AnnotatorError("invalid_rule", f"list_meta.direction 不支持: {direction}", 400)
 
-        list_type = str(list_meta.get("type", "image")).strip() or "image"
+        list_type = str(list_meta.get("type", field_default("list", "type", "image"))).strip() or field_default("list", "type", "image")
         if list_type not in ALLOWED_LIST_MODE:
             raise AnnotatorError("invalid_rule", f"list_meta.type 不支持: {list_type}", 400)
 
@@ -986,11 +1000,11 @@ class AnnotatorManager:
 
         if rule_type == "list":
             list_meta = {
-                "name": str(data.get("name", "list_name")),
-                "direction": str(data.get("direction", "vertical")),
-                "type": str(data.get("type", "image")),
-                "roiBack": str(data.get("roiBack", "0,0,100,100")),
-                "description": str(data.get("description", "")),
+                "name": str(data.get("name", field_default("list", "name", "list_name"))),
+                "direction": str(data.get("direction", field_default("list", "direction", "vertical"))),
+                "type": str(data.get("type", field_default("list", "type", "image"))),
+                "roiBack": str(data.get("roiBack", default_list_meta().get("roiBack", "0,0,100,100"))),
+                "description": str(data.get("description", field_default("list", "description", ""))),
             }
             for item in data.get("list", []):
                 if not isinstance(item, dict):
@@ -1059,7 +1073,11 @@ class AnnotatorManager:
                         }
                     )
 
-        rule_type_locked = rule_type in {"image", "ocr", "click", "swipe", "long_click", "list"} and len(rules) > 0
+        if rule_type == "list":
+            list_meta = merge_list_meta_with_defaults(list_meta)
+        rules = [merge_rule_with_defaults(rule_type, item) for item in rules]
+
+        rule_type_locked = rule_type in ALLOWED_RULE_TYPE and len(rules) > 0
 
         return {
             "task_name": task_name,
@@ -1165,7 +1183,7 @@ class AnnotatorManager:
             image_name = str(rule.get("imageName", "")).strip()
             if not image_name:
                 raise AnnotatorError("invalid_rule", "image 规则缺少 imageName", 400)
-            method = str(rule.get("method", "Template matching")).strip() or "Template matching"
+            method = str(rule.get("method", field_default("image", "method", "Template matching"))).strip() or field_default("image", "method", "Template matching")
             try:
                 threshold = float(rule.get("threshold", 0.8))
             except (TypeError, ValueError) as e:
@@ -1198,7 +1216,7 @@ class AnnotatorManager:
 
         if rule_type == "ocr":
             item_name = str(rule.get("itemName", "")).strip() or "unnamed"
-            mode = str(rule.get("mode", "Single")).strip() or "Single"
+            mode = str(rule.get("mode", field_default("ocr", "mode", "Single"))).strip() or field_default("ocr", "mode", "Single")
             method = str(rule.get("method", "Default")).strip() or "Default"
             keyword = str(rule.get("keyword", "")).strip()
             roi_front = self._parse_roi_tuple(str(rule.get("roiFront", "")))
@@ -1234,7 +1252,7 @@ class AnnotatorManager:
             if not item_name:
                 raise AnnotatorError("invalid_rule", "list 项缺少 itemName", 400)
 
-            list_type = str(list_meta.get("type", "image")).strip() or "image"
+            list_type = str(list_meta.get("type", field_default("list", "type", "image"))).strip() or field_default("list", "type", "image")
             if list_type not in ALLOWED_LIST_MODE:
                 raise AnnotatorError("invalid_rule", f"list_meta.type 不支持: {list_type}", 400)
             list_roi_back = self._parse_roi_tuple(str(list_meta.get("roiBack", "")))

--- a/module/server/tool_router.py
+++ b/module/server/tool_router.py
@@ -216,6 +216,15 @@ async def annotator_task_json_files(task_name: str):
         _raise_annotator_error(e)
 
 
+@tool_app.get('/annotator/api/rules/schema')
+async def annotator_rule_schema():
+    try:
+        data = annotator_manager.rule_schema()
+        return {"code": "ok", **data}
+    except AnnotatorError as e:
+        _raise_annotator_error(e)
+
+
 @tool_app.get('/annotator/api/rules/load')
 async def annotator_load_rules(task_name: str, json_relpath: str):
     try:

--- a/module/server/web/annotator/static/js/app.js
+++ b/module/server/web/annotator/static/js/app.js
@@ -1,8 +1,6 @@
 (function () {
   const API_PREFIX = "/tool/annotator";
-  const OcrModes = ["Single", "Full", "Digit", "DigitCounter", "Duration"];
-  const SwipeModes = ["default", "vector"];
-  const AllowedRuleTypes = new Set(["image", "ocr", "click", "swipe", "long_click", "list"]);
+  const AllowedRuleTypes = new Set();
 
   const state = {
     sessionId: "",
@@ -32,6 +30,8 @@
 
     ruleType: "image",
     ruleTypeLocked: false,
+    ruleSchemas: [],
+    ruleSchemaMap: new Map(),
     rules: [],
     activeRuleIndex: -1,
     listMeta: {
@@ -108,36 +108,279 @@
     ruleTypeLockTip: document.getElementById("ruleTypeLockTip"),
 
     listMetaBox: document.getElementById("listMetaBox"),
-    listName: document.getElementById("listName"),
-    listDirection: document.getElementById("listDirection"),
-    listType: document.getElementById("listType"),
-    listDescription: document.getElementById("listDescription"),
+    listMetaFields: document.getElementById("listMetaFields"),
+    listName: null,
+    listDirection: null,
+    listType: null,
+    listDescription: null,
 
     ruleList: document.getElementById("ruleList"),
     addRuleBtn: document.getElementById("addRuleBtn"),
     deleteRuleBtn: document.getElementById("deleteRuleBtn"),
     refreshRulesBtn: document.getElementById("refreshRulesBtn"),
 
-    itemName: document.getElementById("itemName"),
-    imageNameWrap: document.getElementById("imageNameWrap"),
-    imageName: document.getElementById("imageName"),
-    methodWrap: document.getElementById("methodWrap"),
-    method: document.getElementById("method"),
-    thresholdWrap: document.getElementById("thresholdWrap"),
-    threshold: document.getElementById("threshold"),
-    modeWrap: document.getElementById("modeWrap"),
-    mode: document.getElementById("mode"),
-    keywordWrap: document.getElementById("keywordWrap"),
-    keyword: document.getElementById("keyword"),
-    durationWrap: document.getElementById("durationWrap"),
-    duration: document.getElementById("duration"),
-    descriptionWrap: document.getElementById("descriptionWrap"),
-    description: document.getElementById("description"),
+    ruleFields: document.getElementById("ruleFields"),
+    itemName: null,
+    imageNameWrap: null,
+    imageName: null,
+    methodWrap: null,
+    method: null,
+    thresholdWrap: null,
+    threshold: null,
+    modeWrap: null,
+    mode: null,
+    keywordWrap: null,
+    keyword: null,
+    durationWrap: null,
+    duration: null,
+    descriptionWrap: null,
+    description: null,
 
     testRuleBtn: document.getElementById("testRuleBtn"),
     saveImageBtn: document.getElementById("saveImageBtn"),
     saveRulesBtn: document.getElementById("saveRulesBtn"),
   };
+
+  function getRuleSchema(type = state.ruleType) {
+    return state.ruleSchemaMap.get(type) || null;
+  }
+
+  function getRuleFields(type = state.ruleType) {
+    const schema = getRuleSchema(type);
+    return schema && Array.isArray(schema.fields) ? schema.fields : [];
+  }
+
+  function getListMetaFields() {
+    const schema = getRuleSchema("list");
+    return schema && Array.isArray(schema.meta_fields) ? schema.meta_fields : [];
+  }
+
+  function getFieldDefault(type, key, fallback = "") {
+    const fields = type === "list"
+      ? [...getRuleFields(type), ...getListMetaFields()]
+      : getRuleFields(type);
+    const field = fields.find((item) => item.key === key);
+    if (!field) {
+      return fallback;
+    }
+    return field.default ?? fallback;
+  }
+
+  function getListMetaDefaults() {
+    const defaults = {
+      name: "list_name",
+      direction: "vertical",
+      type: "image",
+      roiBack: "0,0,100,100",
+      description: "",
+    };
+    for (const field of getListMetaFields()) {
+      defaults[field.key] = field.default ?? defaults[field.key] ?? "";
+    }
+    return defaults;
+  }
+
+  function getRuleFieldDomId(key) {
+    return key;
+  }
+
+  function getRuleFieldWrapId(key) {
+    return `${key}Wrap`;
+  }
+
+  function getListMetaFieldDomId(key) {
+    if (key === "name") {
+      return "listName";
+    }
+    if (key === "direction") {
+      return "listDirection";
+    }
+    if (key === "type") {
+      return "listType";
+    }
+    if (key === "description") {
+      return "listDescription";
+    }
+    return `list${key}`;
+  }
+
+  function createFieldControl(field, domId, wrapId = "") {
+    const label = document.createElement("label");
+    if (wrapId) {
+      label.id = wrapId;
+    }
+    if (field.full) {
+      label.classList.add("full");
+    }
+    label.append(document.createTextNode(field.label));
+
+    let control = null;
+    if (field.control === "textarea") {
+      control = document.createElement("textarea");
+    } else if (field.control === "select") {
+      control = document.createElement("select");
+      for (const optionValue of field.options || []) {
+        createOption(control, optionValue, optionValue);
+      }
+    } else {
+      control = document.createElement("input");
+      control.type = field.control === "number" ? "number" : "text";
+    }
+
+    control.id = domId;
+    if (field.step !== undefined && "step" in control) {
+      control.step = String(field.step);
+    }
+    if (field.min !== undefined && "min" in control) {
+      control.min = String(field.min);
+    }
+    if (field.max !== undefined && "max" in control) {
+      control.max = String(field.max);
+    }
+    label.appendChild(control);
+    return label;
+  }
+
+  function renderFieldGroup(container, fields, domIdResolver, wrapIdResolver = null) {
+    if (!container) {
+      return;
+    }
+    container.innerHTML = "";
+    for (const field of fields) {
+      const domId = domIdResolver(field.key);
+      const wrapId = wrapIdResolver ? wrapIdResolver(field.key) : "";
+      container.appendChild(createFieldControl(field, domId, wrapId));
+    }
+  }
+
+  function refreshDynamicFieldRefs() {
+    el.itemName = document.getElementById("itemName");
+    el.imageNameWrap = document.getElementById("imageNameWrap");
+    el.imageName = document.getElementById("imageName");
+    el.methodWrap = document.getElementById("methodWrap");
+    el.method = document.getElementById("method");
+    el.thresholdWrap = document.getElementById("thresholdWrap");
+    el.threshold = document.getElementById("threshold");
+    el.modeWrap = document.getElementById("modeWrap");
+    el.mode = document.getElementById("mode");
+    el.keywordWrap = document.getElementById("keywordWrap");
+    el.keyword = document.getElementById("keyword");
+    el.durationWrap = document.getElementById("durationWrap");
+    el.duration = document.getElementById("duration");
+    el.descriptionWrap = document.getElementById("descriptionWrap");
+    el.description = document.getElementById("description");
+
+    el.listName = document.getElementById("listName");
+    el.listDirection = document.getElementById("listDirection");
+    el.listType = document.getElementById("listType");
+    el.listDescription = document.getElementById("listDescription");
+  }
+
+  function bindRuleFieldChange(element, fieldKey) {
+    if (!element) {
+      return;
+    }
+    const eventName = element.tagName === "SELECT" ? "change" : "input";
+    element.addEventListener(eventName, () => updateRuleFromForm(fieldKey));
+  }
+
+  function bindDynamicFieldEvents() {
+    bindRuleFieldChange(el.itemName, "itemName");
+    bindRuleFieldChange(el.imageName, "imageName");
+    bindRuleFieldChange(el.method, "method");
+    bindRuleFieldChange(el.threshold, "threshold");
+    bindRuleFieldChange(el.mode, "mode");
+    bindRuleFieldChange(el.keyword, "keyword");
+    bindRuleFieldChange(el.duration, "duration");
+    bindRuleFieldChange(el.description, "description");
+
+    if (el.listName) {
+      el.listName.addEventListener("input", () => {
+        updateListMetaFromForm();
+        markDirty();
+      });
+    }
+    if (el.listDirection) {
+      el.listDirection.addEventListener("change", () => {
+        updateListMetaFromForm();
+        markDirty();
+        updateFieldVisibility();
+      });
+    }
+    if (el.listType) {
+      el.listType.addEventListener("change", () => {
+        updateListMetaFromForm();
+        clearTestOverlay();
+        renderRuleList();
+        markDirty();
+        updateFieldVisibility();
+      });
+    }
+    if (el.listDescription) {
+      el.listDescription.addEventListener("input", () => {
+        updateListMetaFromForm();
+        markDirty();
+      });
+    }
+  }
+
+  function renderDynamicFieldGroups() {
+    renderFieldGroup(el.ruleFields, getRuleFields(), getRuleFieldDomId, getRuleFieldWrapId);
+    renderFieldGroup(el.listMetaFields, getListMetaFields(), getListMetaFieldDomId);
+    refreshDynamicFieldRefs();
+    bindDynamicFieldEvents();
+  }
+
+  function populateRuleTypeOptions() {
+    el.ruleType.innerHTML = "";
+    for (const schema of state.ruleSchemas) {
+      createOption(el.ruleType, schema.type, schema.label || schema.type);
+    }
+  }
+
+  async function loadRuleSchemas() {
+    const res = await api(`${API_PREFIX}/api/rules/schema`);
+    const schemas = res.schemas || {};
+    const ruleTypes = Array.isArray(res.rule_types) ? res.rule_types : Object.keys(schemas);
+    state.ruleSchemas = ruleTypes.map((type) => schemas[type]).filter(Boolean);
+    state.ruleSchemaMap = new Map(state.ruleSchemas.map((schema) => [schema.type, schema]));
+    AllowedRuleTypes.clear();
+    for (const schema of state.ruleSchemas) {
+      AllowedRuleTypes.add(schema.type);
+    }
+    populateRuleTypeOptions();
+    if (!AllowedRuleTypes.has(state.ruleType)) {
+      state.ruleType = state.ruleSchemas[0] ? state.ruleSchemas[0].type : "image";
+    }
+    renderDynamicFieldGroups();
+  }
+
+  function setElementValue(element, value) {
+    if (!element) {
+      return;
+    }
+    element.value = value ?? "";
+  }
+
+  function readFieldValue(field, element) {
+    if (!element) {
+      return field.default ?? "";
+    }
+    if (field.control === "number") {
+      const raw = String(element.value || "").trim();
+      if (field.integer) {
+        const parsed = Number.parseInt(raw, 10);
+        return Number.isFinite(parsed) ? parsed : (field.default ?? 0);
+      }
+      const parsed = Number.parseFloat(raw);
+      return Number.isFinite(parsed) ? parsed : (field.default ?? 0);
+    }
+    const value = String(element.value || "").trim();
+    if (!value && field.default !== undefined) {
+      return field.default;
+    }
+    return value;
+  }
 
   function showMessage(text, type = "") {
     const message = String(text || "").trim();
@@ -1153,75 +1396,33 @@
   }
 
   function resetListMeta() {
-    state.listMeta = {
-      name: "list_name",
-      direction: "vertical",
-      type: "image",
-      roiBack: "0,0,100,100",
-      description: "",
-    };
+    state.listMeta = getListMetaDefaults();
   }
 
   function defaultRuleByType(type) {
+    const rule = {};
+    for (const field of getRuleFields(type)) {
+      rule[field.key] = field.default ?? "";
+    }
+    rule.itemName = String(rule.itemName || "new");
+    rule.roiFront = "0,0,100,100";
+    if (type !== "list") {
+      rule.roiBack = "0,0,100,100";
+    }
     if (type === "image") {
-      return {
-        itemName: "new",
-        imageName: defaultImageNameForItem("new"),
-        roiFront: "0,0,100,100",
-        roiBack: "0,0,100,100",
-        method: "Template matching",
-        threshold: 0.8,
-        description: "",
-        __autoImageName: true,
-      };
+      rule.imageName = String(rule.imageName || "").trim() || defaultImageNameForItem(rule.itemName || "new");
+      rule.__autoImageName = true;
     }
-    if (type === "ocr") {
-      return {
-        itemName: "new",
-        roiFront: "0,0,100,100",
-        roiBack: "0,0,100,100",
-        mode: "Single",
-        method: "Default",
-        keyword: "",
-        description: "",
-      };
+    if (type === "list") {
+      delete rule.description;
     }
-    if (type === "click") {
-      return {
-        itemName: "new",
-        roiFront: "0,0,100,100",
-        roiBack: "0,0,100,100",
-        description: "",
-      };
-    }
-    if (type === "swipe") {
-      return {
-        itemName: "new",
-        roiFront: "0,0,100,100",
-        roiBack: "0,0,100,100",
-        mode: "default",
-        description: "",
-      };
-    }
-    if (type === "long_click") {
-      return {
-        itemName: "new",
-        roiFront: "0,0,100,100",
-        roiBack: "0,0,100,100",
-        duration: 1000,
-        description: "",
-      };
-    }
-    return {
-      itemName: "new",
-      roiFront: "0,0,100,100",
-    };
+    return rule;
   }
 
   function normalizeLoadedRules(type, rules) {
     const result = [];
     for (const raw of rules || []) {
-      const item = { ...raw };
+      const item = { ...defaultRuleByType(type), ...(raw || {}) };
       if (type === "image") {
         const autoName = defaultImageNameForItem(item.itemName || "");
         item.__autoImageName = !item.imageName || item.imageName === autoName;
@@ -1237,37 +1438,14 @@
   function cloneRules(rules) {
     return (rules || []).map((rule) => ({ ...rule }));
   }
-  function updateModeOptions() {
-    const oldValue = el.mode.value;
-    if (state.ruleType === "ocr") {
-      el.mode.innerHTML = OcrModes.map((item) => `<option value="${item}">${item}</option>`).join("");
-      el.mode.value = OcrModes.includes(oldValue) ? oldValue : "Single";
-      return;
-    }
-    if (state.ruleType === "swipe") {
-      el.mode.innerHTML = SwipeModes.map((item) => `<option value="${item}">${item}</option>`).join("");
-      el.mode.value = SwipeModes.includes(oldValue) ? oldValue : "default";
-      return;
-    }
-    el.mode.innerHTML = '<option value="default">default</option>';
-    el.mode.value = "default";
-  }
 
   function updateFieldVisibility() {
     const type = state.ruleType;
-    el.imageNameWrap.classList.toggle("hidden", type !== "image");
-    el.methodWrap.classList.toggle("hidden", type !== "image");
-    el.thresholdWrap.classList.toggle("hidden", type !== "image");
-    el.modeWrap.classList.toggle("hidden", !(type === "ocr" || type === "swipe"));
-    el.keywordWrap.classList.toggle("hidden", type !== "ocr");
-    el.durationWrap.classList.toggle("hidden", type !== "long_click");
     el.listMetaBox.classList.toggle("hidden", type !== "list");
-    el.descriptionWrap.classList.toggle("hidden", type === "list");
 
     const showSaveImage = type === "image" || isListImageRule();
     el.saveImageBtn.classList.toggle("hidden", !showSaveImage);
 
-    updateModeOptions();
     refreshActiveRuleImageExists().catch(() => {
       // ignore
     });
@@ -1508,14 +1686,10 @@
   }
 
   function clearRuleForm() {
-    el.itemName.value = "";
-    el.imageName.value = "";
-    el.method.value = "";
-    el.threshold.value = "";
-    el.mode.value = "default";
-    el.keyword.value = "";
-    el.duration.value = "";
-    el.description.value = "";
+    for (const field of getRuleFields()) {
+      const element = document.getElementById(getRuleFieldDomId(field.key));
+      setElementValue(element, field.default ?? "");
+    }
     el.roiFrontValue.value = "";
     el.roiBackValue.value = "";
     refreshRoiLayoutFromRule();
@@ -1523,17 +1697,19 @@
   }
 
   function fillListMetaForm() {
-    el.listName.value = state.listMeta.name || "";
-    el.listDirection.value = state.listMeta.direction || "vertical";
-    el.listType.value = state.listMeta.type || "image";
-    el.listDescription.value = state.listMeta.description || "";
+    const defaults = getListMetaDefaults();
+    for (const field of getListMetaFields()) {
+      const element = document.getElementById(getListMetaFieldDomId(field.key));
+      setElementValue(element, state.listMeta[field.key] ?? defaults[field.key] ?? "");
+    }
   }
 
   function updateListMetaFromForm() {
-    state.listMeta.name = el.listName.value.trim() || "list_name";
-    state.listMeta.direction = el.listDirection.value || "vertical";
-    state.listMeta.type = el.listType.value || "image";
-    state.listMeta.description = el.listDescription.value.trim();
+    const defaults = getListMetaDefaults();
+    for (const field of getListMetaFields()) {
+      const element = document.getElementById(getListMetaFieldDomId(field.key));
+      state.listMeta[field.key] = readFieldValue(field, element) ?? defaults[field.key] ?? "";
+    }
   }
 
   function fillRuleForm() {
@@ -1543,14 +1719,10 @@
       return;
     }
 
-    el.itemName.value = rule.itemName || "";
-    el.imageName.value = rule.imageName || "";
-    el.method.value = rule.method || "";
-    el.threshold.value = rule.threshold ?? "";
-    el.mode.value = rule.mode || "default";
-    el.keyword.value = rule.keyword || "";
-    el.duration.value = rule.duration ?? "";
-    el.description.value = state.ruleType === "list" ? "" : (rule.description || "");
+    for (const field of getRuleFields()) {
+      const element = document.getElementById(getRuleFieldDomId(field.key));
+      setElementValue(element, rule[field.key] ?? field.default ?? "");
+    }
 
     const front = rule.roiFront || "0,0,100,100";
     const back = state.ruleType === "list" ? (state.listMeta.roiBack || "0,0,100,100") : (rule.roiBack || "0,0,100,100");
@@ -1570,33 +1742,33 @@
     }
 
     const oldPreviewImageName = getRulePreviewImageName(rule);
-    const newItemName = el.itemName.value.trim() || "unnamed";
-
-    rule.itemName = newItemName;
-    if (state.ruleType !== "list") {
-      rule.description = el.description.value.trim();
+    for (const field of getRuleFields()) {
+      if (state.ruleType === "image" && field.key === "imageName" && changedField === "itemName") {
+        continue;
+      }
+      const element = document.getElementById(getRuleFieldDomId(field.key));
+      rule[field.key] = readFieldValue(field, element);
     }
+
+    const newItemName = String(rule.itemName || "").trim() || "unnamed";
+    rule.itemName = newItemName;
 
     if (state.ruleType === "image") {
       if (changedField === "itemName") {
         rule.imageName = defaultImageNameForItem(newItemName);
         rule.__autoImageName = true;
-        el.imageName.value = rule.imageName;
+        setElementValue(el.imageName, rule.imageName);
       } else {
-        const imageNameInput = el.imageName.value.trim();
+        const imageNameInput = String(el.imageName && el.imageName.value || "").trim();
         if (imageNameInput) {
           rule.imageName = imageNameInput;
           rule.__autoImageName = imageNameInput === defaultImageNameForItem(newItemName);
         } else {
           rule.imageName = defaultImageNameForItem(newItemName);
           rule.__autoImageName = true;
-          el.imageName.value = rule.imageName;
+          setElementValue(el.imageName, rule.imageName);
         }
       }
-
-      rule.method = el.method.value.trim() || "Template matching";
-      const threshold = Number.parseFloat(el.threshold.value);
-      rule.threshold = Number.isFinite(threshold) ? threshold : 0.8;
 
       const nextImageName = String(rule.imageName || "").trim();
       if (oldPreviewImageName !== nextImageName || changedField === "itemName") {
@@ -1604,21 +1776,6 @@
         clearRuleImageCache(rule);
         state.activeRuleImageExists = false;
       }
-    }
-
-    if (state.ruleType === "ocr") {
-      rule.mode = el.mode.value || "Single";
-      rule.method = el.method.value.trim() || "Default";
-      rule.keyword = el.keyword.value.trim();
-    }
-
-    if (state.ruleType === "swipe") {
-      rule.mode = el.mode.value || "default";
-    }
-
-    if (state.ruleType === "long_click") {
-      const duration = Number.parseInt(el.duration.value, 10);
-      rule.duration = Number.isFinite(duration) ? Math.max(1, duration) : 1000;
     }
 
     if (state.ruleType === "list") {
@@ -1656,8 +1813,9 @@
   }
 
   function setRuleType(nextType) {
-    state.ruleType = AllowedRuleTypes.has(nextType) ? nextType : "image";
+    state.ruleType = AllowedRuleTypes.has(nextType) ? nextType : (state.ruleSchemas[0] ? state.ruleSchemas[0].type : "image");
     el.ruleType.value = state.ruleType;
+    renderDynamicFieldGroups();
     updateFieldVisibility();
   }
 
@@ -2540,36 +2698,6 @@
       el.refreshRulesBtn.addEventListener("click", withError(refreshRulesList));
     }
 
-    el.itemName.addEventListener("input", () => updateRuleFromForm("itemName"));
-    el.imageName.addEventListener("input", () => updateRuleFromForm("imageName"));
-    el.method.addEventListener("input", () => updateRuleFromForm("method"));
-    el.threshold.addEventListener("input", () => updateRuleFromForm("threshold"));
-    el.mode.addEventListener("change", () => updateRuleFromForm("mode"));
-    el.keyword.addEventListener("input", () => updateRuleFromForm("keyword"));
-    el.duration.addEventListener("input", () => updateRuleFromForm("duration"));
-    el.description.addEventListener("input", () => updateRuleFromForm("description"));
-
-    el.listName.addEventListener("input", () => {
-      updateListMetaFromForm();
-      markDirty();
-    });
-    el.listDirection.addEventListener("change", () => {
-      updateListMetaFromForm();
-      markDirty();
-      updateFieldVisibility();
-    });
-    el.listType.addEventListener("change", () => {
-      updateListMetaFromForm();
-      clearTestOverlay();
-      renderRuleList();
-      markDirty();
-      updateFieldVisibility();
-    });
-    el.listDescription.addEventListener("input", () => {
-      updateListMetaFromForm();
-      markDirty();
-    });
-
     el.testRuleBtn.addEventListener("click", withError(testCurrentRule));
     el.saveImageBtn.addEventListener("click", withError(saveImageCrop));
     el.saveRulesBtn.addEventListener("click", withError(saveRules));
@@ -2595,10 +2723,11 @@
   async function init() {
     setupRoiBox(el.roiFront);
     setupRoiBox(el.roiBack);
+    await loadRuleSchemas();
     bindEvents();
 
     resetListMeta();
-    state.rules = [defaultRuleByType("image")];
+    state.rules = [defaultRuleByType(state.ruleType)];
     state.activeRuleIndex = 0;
     renderRuleList();
 

--- a/module/server/web/annotator/static/widget/right-window.html
+++ b/module/server/web/annotator/static/widget/right-window.html
@@ -21,31 +21,11 @@
         <h2>规则</h2>
         <div class="rule-editor-scroll">
           <label>规则类型
-            <select id="ruleType">
-              <option value="image">RuleImage</option>
-              <option value="ocr">RuleOcr</option>
-              <option value="click">RuleClick</option>
-              <option value="swipe">RuleSwipe</option>
-              <option value="long_click">RuleLongClick</option>
-              <option value="list">RuleList</option>
-            </select>
+            <select id="ruleType"></select>
           </label>
 
           <div id="listMetaBox" class="block hidden">
-            <label>list.name<input id="listName" type="text"></label>
-            <label>list.direction
-              <select id="listDirection">
-                <option value="vertical">vertical</option>
-                <option value="horizontal">horizontal</option>
-              </select>
-            </label>
-            <label>list.type
-              <select id="listType">
-                <option value="image">image</option>
-                <option value="ocr">ocr</option>
-              </select>
-            </label>
-            <label>list.description<input id="listDescription" type="text"></label>
+            <div id="listMetaFields" class="form-grid"></div>
           </div>
 
           <div class="row">
@@ -58,26 +38,7 @@
           <div class="rule-list-splitter" id="ruleListSplitter" aria-hidden="true"></div>
 
           <div class="rule-detail-scroll">
-            <div class="form-grid">
-              <label>itemName<input id="itemName" type="text"></label>
-              <label id="imageNameWrap">imageName<input id="imageName" type="text"></label>
-              <label id="methodWrap">method<input id="method" type="text"></label>
-              <label id="thresholdWrap">threshold<input id="threshold" type="number" step="0.01" min="0" max="1"></label>
-              <label id="modeWrap" class="hidden">mode
-                <select id="mode">
-                  <option value="default">default</option>
-                  <option value="Single">Single</option>
-                  <option value="Full">Full</option>
-                  <option value="Digit">Digit</option>
-                  <option value="DigitCounter">DigitCounter</option>
-                  <option value="Duration">Duration</option>
-                  <option value="vector">vector</option>
-                </select>
-              </label>
-              <label id="keywordWrap" class="hidden">keyword<input id="keyword" type="text"></label>
-              <label id="durationWrap" class="hidden">duration(ms)<input id="duration" type="number" min="1" step="1"></label>
-              <label id="descriptionWrap" class="full">description<textarea id="description"></textarea></label>
-            </div>
+            <div class="form-grid" id="ruleFields"></div>
 
             <div class="row action-row">
               <button id="saveImageBtn" type="button" class="hidden">裁剪</button>
@@ -94,4 +55,3 @@
     <button type="button" class="rail-btn" data-window="right" data-panel-id="ruleEditorPanel" title="规则">规则</button>
   </div>
 </aside>
-


### PR DESCRIPTION
- 移除硬编码的规则类型常量，改为动态加载规则模式
- 添加规则架构定义文件，支持可配置的字段类型和验证
- 实现动态表单渲染，根据规则类型显示相应字段
- 创建字段默认值管理系统和字段类型验证
- 添加API端点用于获取规则架构信息
- 实现规则类型切换时的动态表单更新
- 重构规则编辑界面，使用动态字段替换静态HTML
- 添加列表元数据的动态字段支持
- 实现规则字段的运行时验证和默认值填充
- 更新后端工具类以使用新的规则架构系统