### PR TITLE
refactor: 将 anti_ban 作息逻辑从 script.py 抽出为 AntiBanGuard

### DIFF
--- a/module/config/anti_ban.py
+++ b/module/config/anti_ban.py
@@ -1,0 +1,54 @@
+# This Python file uses the following encoding: utf-8
+"""防风控作息看守器: 睡眠窗 / 每日活跃上限 / 强制长休息, 由 Script 持有。"""
+from datetime import datetime, timedelta
+
+
+class AntiBanGuard:
+    def __init__(self) -> None:
+        self.reset()
+
+    def reset(self) -> None:
+        self._active_date = None
+        self._active_seconds_today = 0.0
+        self._rest_until = None
+
+    @staticmethod
+    def _in_sleep_window(t, start, end) -> bool:
+        if start == end:
+            return False
+        if start < end:
+            return start <= t < end
+        return t >= start or t < end
+
+    @staticmethod
+    def _next_time_point(now: datetime, end) -> datetime:
+        candidate = now.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
+        if candidate <= now:
+            candidate += timedelta(days=1)
+        return candidate
+
+    def _roll_day(self, today) -> None:
+        if self._active_date != today:
+            self._active_date = today
+            self._active_seconds_today = 0.0
+
+    def record_active(self, seconds: float) -> None:
+        self._roll_day(datetime.now().date())
+        self._active_seconds_today += seconds
+
+    def wake_time(self, now: datetime, config):
+        if not config.enable:
+            return None
+        wake = None
+        if self._in_sleep_window(now.time(), config.sleep_start, config.sleep_end):
+            wake = self._next_time_point(now, config.sleep_end)
+        limit = config.daily_active_limit.total_seconds()
+        if limit > 0:
+            self._roll_day(now.date())
+            if self._rest_until and now < self._rest_until:
+                wake = max(wake, self._rest_until) if wake else self._rest_until
+            elif self._active_seconds_today >= limit:
+                self._rest_until = now + config.long_rest_duration
+                self._active_seconds_today = 0.0
+                wake = max(wake, self._rest_until) if wake else self._rest_until
+        return wake

--- a/script.py
+++ b/script.py
@@ -30,6 +30,7 @@ from module.config.utils import convert_to_underscore
 from module.config.config import Config
 from module.config.config_model import ConfigModel
 from module.config.instance_guard import InstanceGuard
+from module.config.anti_ban import AntiBanGuard
 from module.device.device import Device
 from module.device.env import IS_WINDOWS
 from module.base.utils import load_module
@@ -61,6 +62,7 @@ class Script:
         self.loop_thread: Thread = None
         # 跨进程排队管理器（仅在 queue_mode=True 时初始化）
         self.instance_guard: InstanceGuard = None
+        self.anti_ban_guard: AntiBanGuard = AntiBanGuard()
 
     @cached_property
     def config(self) -> "Config":
@@ -318,42 +320,6 @@ class Script:
             if self.config.should_reload():
                 return False
 
-    @staticmethod
-    def _in_sleep_window(t, start, end) -> bool:
-        if start == end:
-            return False
-        if start < end:
-            return start <= t < end
-        return t >= start or t < end
-
-    @staticmethod
-    def _next_time_point(now: datetime, end) -> datetime:
-        candidate = now.replace(hour=end.hour, minute=end.minute, second=end.second, microsecond=0)
-        if candidate <= now:
-            candidate += timedelta(days=1)
-        return candidate
-
-    def _antiban_wake_time(self, now: datetime):
-        ab = self.config.script.anti_ban
-        if not ab.enable:
-            return None
-        wake = None
-        if self._in_sleep_window(now.time(), ab.sleep_start, ab.sleep_end):
-            wake = self._next_time_point(now, ab.sleep_end)
-        limit = ab.daily_active_limit.total_seconds()
-        if limit > 0:
-            if getattr(self, '_active_date', None) != now.date():
-                self._active_date = now.date()
-                self._active_seconds_today = 0
-            rest_until = getattr(self, '_rest_until', None)
-            if rest_until and now < rest_until:
-                wake = max(wake, rest_until) if wake else rest_until
-            elif getattr(self, '_active_seconds_today', 0) >= limit:
-                self._rest_until = now + ab.long_rest_duration
-                self._active_seconds_today = 0
-                wake = max(wake, self._rest_until) if wake else self._rest_until
-        return wake
-
     def get_next_task(self) -> str:
         """
         获取下一个任务的名字, 大驼峰。
@@ -365,7 +331,7 @@ class Script:
             if self.state_queue:
                 self.state_queue.put({"schedule": self.config.get_schedule_data()})
             now = datetime.now()
-            antiban_wake = self._antiban_wake_time(now)
+            antiban_wake = self.anti_ban_guard.wake_time(now, self.config.script.anti_ban)
             if antiban_wake is not None:
                 task.next_run = max(task.next_run, antiban_wake)
             if not self._try_acquire_queue_token():
@@ -664,9 +630,7 @@ class Script:
         start_day = date.today()
         logger.info(f'Start scheduler loop: {self.config_name}')
         self.config.model.running_task = ''
-        self._active_seconds_today = 0
-        self._active_date = date.today()
-        self._rest_until = None
+        self.anti_ban_guard.reset()
 
         # Update GUI 防呆, 读取设置并立刻显示后台模拟器到前台
         if not self.config.script.device.run_background_only and IS_WINDOWS:
@@ -727,10 +691,7 @@ class Script:
             self.config.model.running_task = ''
             logger.info(f'Scheduler: End task `{task}`')
             self.is_first_task = False
-            if self._active_date != date.today():
-                self._active_date = date.today()
-                self._active_seconds_today = 0
-            self._active_seconds_today += (datetime.now() - _task_start).total_seconds()
+            self.anti_ban_guard.record_active((datetime.now() - _task_start).total_seconds())
 
             # Check failures
             # failed = deep_get(self.failure_record, keys=task, default=0)


### PR DESCRIPTION
原本散插进 script.py 四处的睡眠窗/每日活跃上限/强制休息逻辑与隐式状态
(_active_*/_rest_until) 收拢为 module/config/anti_ban.py 的 AntiBanGuard, 镜像 InstanceGuard 范式。script.py 只留 import + 构造 + 三处一行调用, 行为完全不变。回应 script.py 变臃肿的反馈。